### PR TITLE
Inscription status back

### DIFF
--- a/src/AppBundle/Admin/ApplicantAdmin.php
+++ b/src/AppBundle/Admin/ApplicantAdmin.php
@@ -28,15 +28,6 @@ class ApplicantAdmin extends Admin
             )
             ->add('member', 'sonata_type_model_list', array('btn_add' => false, 'btn_delete' => false))
             ->add('appliedAt', 'sonata_type_datetime_picker')
-            ->add(
-                'status',
-                'choice',
-                array(
-                    'required' => true,
-                    'choices' => Applicant::getStatuses(),
-                    'translation_domain' => 'SonataAdminApplicant',
-                )
-            )
             ->end();
 
         if (!is_numeric($formMapper->getFormBuilder()->getForm()->getName())) {
@@ -72,8 +63,7 @@ class ApplicantAdmin extends Admin
             ->add('event')
             ->add('member.fullName')
             ->add('nrRecipes')
-            ->add('nrVotes')
-            ->add('status', 'trans', array('catalogue' => 'SonataAdminApplicant'));
+            ->add('nrVotes');
     }
 
     /**
@@ -97,16 +87,6 @@ class ApplicantAdmin extends Admin
     {
         $datagridMapper
             ->add('event.id')
-            ->add('member')
-            ->add(
-                'status',
-                null,
-                array(),
-                'choice',
-                array(
-                    'choices' => Applicant::getStatuses(),
-                    'translation_domain' => 'SonataAdminApplicant',
-                )
-            );
+            ->add('member');
     }
 }

--- a/src/AppBundle/Entity/Applicant.php
+++ b/src/AppBundle/Entity/Applicant.php
@@ -14,9 +14,8 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Applicant
 {
-    const STATUS_PENDING = 'pending';
     const STATUS_ACCEPTED = 'accepted';
-    const STATUS_REJECTED = 'rejected';
+
 
     /**
      * @ORM\Column(type="integer")
@@ -77,7 +76,7 @@ class Applicant
 
     public function __construct()
     {
-        $this->status = self::STATUS_PENDING;
+        $this->status = self::STATUS_ACCEPTED;
         $this->recipes = new ArrayCollection();
         $this->cookWith = new ArrayCollection();
     }
@@ -146,30 +145,12 @@ class Applicant
         if (!in_array(
             $status,
             array(
-                self::STATUS_PENDING,
                 self::STATUS_ACCEPTED,
-                self::STATUS_REJECTED,
             )
         )) {
             throw new \InvalidArgumentException("Invalid status");
         }
         $this->status = $status;
-    }
-
-    /**
-     * @return int
-     */
-    public function getNrVotes()
-    {
-        return $this->nrVotes;
-    }
-
-    /**
-     * @param int $nrVotes
-     */
-    public function setNrVotes($nrVotes)
-    {
-        $this->nrVotes = $nrVotes;
     }
 
     /**
@@ -231,8 +212,6 @@ class Applicant
     {
         $prices =  array(
             self::STATUS_ACCEPTED,
-            self::STATUS_REJECTED,
-            self::STATUS_PENDING
         );
 
         return array_combine($prices, $prices);

--- a/src/AppBundle/Entity/Applicant.php
+++ b/src/AppBundle/Entity/Applicant.php
@@ -16,7 +16,6 @@ class Applicant
 {
     const STATUS_ACCEPTED = 'accepted';
 
-
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
@@ -151,6 +150,22 @@ class Applicant
             throw new \InvalidArgumentException("Invalid status");
         }
         $this->status = $status;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNrVotes()
+    {
+        return $this->nrVotes;
+    }
+
+    /**
+     * @param int $nrVotes
+     */
+    public function setNrVotes($nrVotes)
+    {
+        $this->nrVotes = $nrVotes;
     }
 
     /**

--- a/src/AppBundle/Entity/Applicant.php
+++ b/src/AppBundle/Entity/Applicant.php
@@ -14,7 +14,9 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Applicant
 {
+    const STATUS_PENDING = 'pending';
     const STATUS_ACCEPTED = 'accepted';
+    const STATUS_REJECTED = 'rejected';
 
     /**
      * @ORM\Column(type="integer")
@@ -144,7 +146,9 @@ class Applicant
         if (!in_array(
             $status,
             array(
+                self::STATUS_PENDING,
                 self::STATUS_ACCEPTED,
+                self::STATUS_REJECTED,
             )
         )) {
             throw new \InvalidArgumentException("Invalid status");
@@ -227,6 +231,8 @@ class Applicant
     {
         $prices =  array(
             self::STATUS_ACCEPTED,
+            self::STATUS_REJECTED,
+            self::STATUS_PENDING,
         );
 
         return array_combine($prices, $prices);

--- a/src/AppBundle/Service/ApplicationManager.php
+++ b/src/AppBundle/Service/ApplicationManager.php
@@ -93,9 +93,8 @@ class ApplicationManager
         $applicant = new Applicant();
         $applicant->setEvent($application->getEvent());
         $applicant->setMember($application->getMember());
-        $applicant->setNrVotes(0);
         $applicant->setAppliedAt(new \DateTime());
-        $applicant->setStatus(Applicant::STATUS_PENDING);
+        $applicant->setStatus(Applicant::STATUS_ACCEPTED);
 
         $this->applicantRepository->save($applicant);
 


### PR DESCRIPTION
I've deleted pending and rejected status options from applicant controllers.
The option is also deleted in the Sonata Admin backoffice : no more status shown.
The initial status is now accepted so the applicant can be automatically registered.
@dbeauseigneur @ngdo-pro @christianJCK @2binfree 